### PR TITLE
typo: crate -> create

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ fn open_cargo_toml(path: &Path) -> Result<CargoToml, String> {
     toml::from_str(&content).map_err(|e| format!("{:?}", e))
 }
 
-/// Crate the not found error.
+/// Create the not found error.
 fn create_not_found_err(orig_name: &str, path: &Display) -> Result<String, String> {
     Err(format!(
         "Could not find `{}` in `dependencies` or `dev-dependencies` in `{}`!",


### PR DESCRIPTION
Thank you for this library 👍

While looking at the source, I noticed this typo.

(at first I thought perhaps there was a typo in the `create_not_found_err` function name, and it should read `crate_not_found_err`. You can go either way, I chose this fix)