### PR TITLE
Fix incorrect dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ Replacement for crate (macro_rules keyword) in proc-macros
 readme = "./README.md"
 
 [dependencies]
-toml = "0.5.0"
+toml = "0.5.2"
 
 [dev-dependencies]
 quote = "1.0.7"


### PR DESCRIPTION
toml version `0.5.0` incorrectly specified serde version `1.0.0` as one of its dependencies, even though it does not work with with serde version `1.0.0`. This [was fixed](https://github.com/alexcrichton/toml-rs/pull/311) and released in version `0.5.2`.

This commit updates the toml dependency to version `0.5.2`. Now `proc-macro-crate` builds fine with the cargo flag [`-Z minimal-versions`](https://github.com/rust-lang/cargo/issues/5657).