### PR TITLE
Also walk `target.'cfg()'` for `dev-dependencies` next to `dependencies`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,8 @@ fn extract_crate_name(
         .and_then(|t| {
             t.values()
                 .filter_map(|v| v.as_table())
-                .filter_map(|t| t.get("dependencies").and_then(|t| t.as_table()))
+                .filter_map(|t| t.get("dependencies").or_else(|| t.get("dev-dependencies")))
+                .filter_map(|t| t.as_table())
                 .find_map(|t| extract_crate_name_from_deps(orig_name, t.clone()))
         })
     {


### PR DESCRIPTION
In [RustAudio/cpal#641] we're seeing a [failure in `ndk-macro`] to turn a crate name with dashes into underscores as fallback, with the underlying issue that `proc-macro-crate` failed to find our crate in `Cargo.toml` when limited to a specific target cfg.  According to [the Rust docs] it is perfectly possible to have `dev-dependencies` behind such a target predicate too.

[RustAudio/cpal#641]: https://github.com/RustAudio/cpal/pull/641#issuecomment-1040470392
[failure in `ndk-macro`]: https://github.com/rust-windowing/android-ndk-rs/blob/9060d5dbea8bdd9aee9e42ef8e8375c35adbc271/ndk-macro/src/helper.rs#L64
[the Rust docs]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies
