### PR TITLE
Fix `dev-dependencies` scan if `target.XYZ` clause also has `dependencies`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,8 @@ fn extract_crate_name(
         .and_then(|t| {
             t.values()
                 .filter_map(|v| v.as_table())
-                .filter_map(|t| t.get("dependencies").or_else(|| t.get("dev-dependencies")))
+                .flat_map(|t| [t.get("dependencies"), t.get("dev-dependencies")])
+                .flatten()
                 .filter_map(|t| t.as_table())
                 .find_map(|t| extract_crate_name_from_deps(orig_name, t.clone()))
         })


### PR DESCRIPTION
In the event that a `dependencies` table exists in addition to the `dev-dependencies` table with the same `target.XYZ` clause, only the `dependencies` table would get read when we instead desire both.

Fixes: c2a4c91 ("Also walk `target.'cfg()'` for `dev-dependencies` next to `dependencies`")
