### PR TITLE
Cache Cargo.toml read result if successful 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "./README.md"
 [dependencies]
 toml = "0.5.2"
 thiserror = "1.0.24"
+once_cell = "1.13.0"
 
 [dev-dependencies]
 quote = "1.0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub fn crate_name(orig_name: &str) -> Result<FoundCrate, Error> {
     let cargo_toml_path = manifest_dir.join("Cargo.toml");
 
     if !cargo_toml_path.exists() {
-        return Err(Error::NotFound(manifest_dir.into()));
+        return Err(Error::NotFound(manifest_dir));
     }
 
     let cargo_toml = open_cargo_toml(&cargo_toml_path)?;
@@ -124,7 +124,7 @@ pub fn crate_name(orig_name: &str) -> Result<FoundCrate, Error> {
 
 /// Make sure that the given crate name is a valid rust identifier.
 fn sanitize_crate_name<S: AsRef<str>>(name: S) -> String {
-    name.as_ref().replace("-", "_")
+    name.as_ref().replace('-', "_")
 }
 
 /// Open the given `Cargo.toml` and parse it into a hashmap.
@@ -221,7 +221,7 @@ fn extract_crate_name_from_deps(orig_name: &str, deps: Table) -> Option<String> 
             .unwrap_or(false);
 
         if key == orig_name || renamed {
-            return Some(key.clone());
+            return Some(key);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@ at your option.
 */
 
 use std::{
-    collections::HashMap,
     env,
     fs::File,
     io::{self, Read},
@@ -65,8 +64,6 @@ use std::{
 };
 
 use toml::{self, value::Table};
-
-type CargoToml = HashMap<String, toml::Value>;
 
 /// Error type used by this crate.
 #[derive(Debug, thiserror::Error)]
@@ -128,7 +125,7 @@ fn sanitize_crate_name<S: AsRef<str>>(name: S) -> String {
 }
 
 /// Open the given `Cargo.toml` and parse it into a hashmap.
-fn open_cargo_toml(path: &Path) -> Result<CargoToml, Error> {
+fn open_cargo_toml(path: &Path) -> Result<Table, Error> {
     let mut content = String::new();
     File::open(path)
         .map_err(|e| Error::CouldNotRead {
@@ -150,7 +147,7 @@ fn open_cargo_toml(path: &Path) -> Result<CargoToml, Error> {
 /// the renamed identifier.
 fn extract_crate_name(
     orig_name: &str,
-    mut cargo_toml: CargoToml,
+    mut cargo_toml: Table,
     cargo_toml_path: &Path,
 ) -> Result<FoundCrate, Error> {
     if let Some(toml::Value::Table(t)) = cargo_toml.get("package") {
@@ -200,7 +197,7 @@ fn extract_crate_name(
 }
 
 /// Search the `orig_name` crate at the given `key` in `cargo_toml`.
-fn search_crate_at_key(key: &str, orig_name: &str, cargo_toml: &mut CargoToml) -> Option<String> {
+fn search_crate_at_key(key: &str, orig_name: &str, cargo_toml: &mut Table) -> Option<String> {
     cargo_toml
         .remove(key)
         .and_then(|v| v.try_into::<Table>().ok())


### PR DESCRIPTION
Closes #19.

Within [ruma-client-api](https://github.com/ruma/ruma/tree/main/crates/ruma-client-api), this reduces compile time of `cargo clean && cargo check --features client` from around 20.5s to around 19s on my machine. Out of that time, around 8.5s are for dependencies that don't use proc-macro-crate, so the real improvement is probably closer to 12s => 10.5s (12.5%).