### PR TITLE
Manually implement Display/Error for Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "./README.md"
 
 [dependencies]
 toml = "0.5.2"
-thiserror = "1.0.24"
 once_cell = "1.13.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This improves build times for crates that depend on this crate, since instead of making a chain in the build graph like this:

- `foo-macro`
  - `syn`
  - `proc-macro-crate`
    - `thiserror`
      - `syn`

Which forces `syn` to be built in series (`syn` then `proc-macro-crate` then `foo-macro`), it instead can look like

- `foo-macro`
  - `syn`
  - `proc-macro-crate`

Which lets it build in parallel (`syn` AND `proc-macro-crate`, then `foo-macro`).
