### PR TITLE
Switch to toml_edit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ Replacement for crate (macro_rules keyword) in proc-macros
 readme = "./README.md"
 
 [dependencies]
-toml = "0.5.2"
+toml_edit = "0.18"
 once_cell = "1.13.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,7 @@ at your option.
 
 use std::{
     collections::btree_map::{self, BTreeMap},
-    env, fmt,
-    fs::{self, File},
-    io::{self, Read},
+    env, fmt, fs, io,
     path::{Path, PathBuf},
     sync::Mutex,
     time::SystemTime,
@@ -216,17 +214,10 @@ fn sanitize_crate_name<S: AsRef<str>>(name: S) -> String {
 
 /// Open the given `Cargo.toml` and parse it into a hashmap.
 fn open_cargo_toml(path: &Path) -> Result<Table, Error> {
-    let mut content = String::new();
-    File::open(path)
-        .map_err(|e| Error::CouldNotRead {
-            source: e,
-            path: path.into(),
-        })?
-        .read_to_string(&mut content)
-        .map_err(|e| Error::CouldNotRead {
-            source: e,
-            path: path.into(),
-        })?;
+    let content = fs::read_to_string(path).map_err(|e| Error::CouldNotRead {
+        source: e,
+        path: path.into(),
+    })?;
     toml::from_str(&content).map_err(|e| Error::InvalidToml { source: e })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ use std::{
 };
 
 use once_cell::sync::Lazy;
-use toml::{self, value::Table};
+use toml_edit::{Document, Item, Table, TomlError};
 
 /// Error type used by this crate.
 #[derive(Debug)]
@@ -73,7 +73,7 @@ pub enum Error {
     NotFound(PathBuf),
     CargoManifestDirNotSet,
     CouldNotRead { path: PathBuf, source: io::Error },
-    InvalidToml { source: toml::de::Error },
+    InvalidToml { source: TomlError },
     CrateNotFound { crate_name: String, path: PathBuf },
 }
 
@@ -213,17 +213,19 @@ fn sanitize_crate_name<S: AsRef<str>>(name: S) -> String {
 }
 
 /// Open the given `Cargo.toml` and parse it into a hashmap.
-fn open_cargo_toml(path: &Path) -> Result<Table, Error> {
+fn open_cargo_toml(path: &Path) -> Result<Document, Error> {
     let content = fs::read_to_string(path).map_err(|e| Error::CouldNotRead {
         source: e,
         path: path.into(),
     })?;
-    toml::from_str(&content).map_err(|e| Error::InvalidToml { source: e })
+    content
+        .parse::<Document>()
+        .map_err(|e| Error::InvalidToml { source: e })
 }
 
 /// Extract all crate names from the given `Cargo.toml` by checking the `dependencies` and
 /// `dev-dependencies`.
-fn extract_crate_names(cargo_toml: &Table) -> Result<CrateNames, Error> {
+fn extract_crate_names(cargo_toml: &Document) -> Result<CrateNames, Error> {
     let package_name = extract_package_name(cargo_toml);
     let root_pkg = package_name.map(|name| {
         let cr = match env::var_os("CARGO_TARGET_TMPDIR") {
@@ -239,8 +241,8 @@ fn extract_crate_names(cargo_toml: &Table) -> Result<CrateNames, Error> {
     let dep_tables = dep_tables(cargo_toml).chain(target_dep_tables(cargo_toml));
     let dep_pkgs = dep_tables.flatten().map(|(dep_name, dep_value)| {
         let pkg_name = dep_value
-            .as_table()
-            .and_then(|t| t.get("package")?.as_str())
+            .get("package")
+            .and_then(|i| i.as_str())
             .unwrap_or(dep_name);
         let cr = FoundCrate::Name(sanitize_crate_name(dep_name));
 
@@ -250,18 +252,19 @@ fn extract_crate_names(cargo_toml: &Table) -> Result<CrateNames, Error> {
     Ok(root_pkg.into_iter().chain(dep_pkgs).collect())
 }
 
-fn extract_package_name(cargo_toml: &Table) -> Option<&str> {
-    cargo_toml.get("package")?.as_table()?.get("name")?.as_str()
+fn extract_package_name(cargo_toml: &Document) -> Option<&str> {
+    cargo_toml.get("package")?.get("name")?.as_str()
 }
 
-fn target_dep_tables(cargo_toml: &Table) -> impl Iterator<Item = &Table> {
+fn target_dep_tables(cargo_toml: &Document) -> impl Iterator<Item = &Table> {
     cargo_toml
         .get("target")
         .into_iter()
-        .filter_map(toml::Value::as_table)
+        .filter_map(Item::as_table)
         .flat_map(|t| {
-            t.values()
-                .filter_map(toml::Value::as_table)
+            t.iter()
+                .map(|(_, value)| value)
+                .filter_map(Item::as_table)
                 .flat_map(dep_tables)
         })
 }
@@ -271,7 +274,7 @@ fn dep_tables(table: &Table) -> impl Iterator<Item = &Table> {
         .get("dependencies")
         .into_iter()
         .chain(table.get("dev-dependencies"))
-        .filter_map(toml::Value::as_table)
+        .filter_map(Item::as_table)
 }
 
 #[cfg(test)]
@@ -286,7 +289,7 @@ mod tests {
         ) => {
             #[test]
             fn $name() {
-                let cargo_toml = toml::from_str($cargo_toml).expect("Parses `Cargo.toml`");
+                let cargo_toml = $cargo_toml.parse::<Document>().expect("Parses `Cargo.toml`");
 
                 match extract_crate_names(&cargo_toml).map(|mut map| map.remove("my_crate")) {
                     $( $result )* => (),


### PR DESCRIPTION
Closes #25.

I could just bump `toml` version to 0.6 since [toml_edit](https://github.com/toml-rs/toml) also provides [toml](https://github.com/toml-rs/toml/tree/main/crates/toml) crate and it replaces [toml on crates.io](https://crates.io/crates/toml). But I decided to use [toml_edit](https://github.com/toml-rs/toml/tree/main/crates/toml_edit) directly to avoid the unneeded `serde` dependency.