### PR TITLE
Update MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = """
 Replacement for crate (macro_rules keyword) in proc-macros
 """
 readme = "./README.md"
-rust-version = "1.60.0"
+rust-version = "1.64.0"
 
 [dependencies]
 toml_edit = "0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "./README.md"
 rust-version = "1.64.0"
 
 [dependencies]
-toml_edit = "0.19"
+toml_edit = "0.19.8"
 once_cell = "1.13.0"
 
 [dev-dependencies]


### PR DESCRIPTION
`toml_edit` updated `winnow` in `0.19.8` which bumps MSRV to 1.64

https://github.com/toml-rs/toml/commit/4bb106680b0e6acc26ca0cb9644e644383a0b726 & https://github.com/toml-rs/toml/commit/9e43da13b04601d9115747610753d73852fbf4c9

could alternatively lock to  `0.19.7` and update MSRV in a new patch. 