### PR TITLE
Bump `syn` to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ once_cell = "1.13.0"
 
 [dev-dependencies]
 quote = "1.0.7"
-syn = "1.0.33"
+syn = "2.0.0"
 proc-macro2 = "1.0.18"


### PR DESCRIPTION
This should help ensure projects don't have to transitively depend on multiple versions of `syn`. `syn`'s current MSRV is 1.56.