### PR TITLE
Remove dep toml_datetime for v2.x.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.66.0"
 
 [dependencies]
 toml_edit = "=0.20.2"
-toml_datetime = "=0.6.3"
 
 [dev-dependencies]
 quote = "1.0.33"


### PR DESCRIPTION
Which causes compilation error when both proc-macro-crate v2 and v3 are in the dependency tree:
```
error: failed to select a version for `toml_datetime`.
    ... required by package `toml_edit v0.21.0`
    ... which satisfies dependency `toml_edit = "^0.21.0"` of package `proc-macro-crate v3.1.0`
    ... which satisfies dependency `proc-macro-crate = "^3.1.0"` of package `parity-scale-codec-derive v3.6.12`
    ... which satisfies dependency `parity-scale-codec-derive = ">=3.6.12"` of package `parity-scale-codec v3.6.12`
 ...
all possible versions conflict with previously selected packages.

  previously selected package `toml_datetime v0.6.3`
    ... which satisfies dependency `toml_datetime = "=0.6.3"` of package `proc-macro-crate v2.0.2`
    ... which satisfies dependency `proc-macro-crate = "^2.0.1"` of package `sp-runtime-interface-proc-macro v11.0.0 (https://github.com/paritytech/polkadot-sdk#b4c81666)`
...
```