### PR TITLE
Disable `display` feature of `toml-edit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ readme = "./README.md"
 rust-version = "1.67.0"
 
 [dependencies]
-toml_edit = "0.22.20"
+toml_edit = { version = "0.22.20", default-features = false, features = [
+    "parse",
+] }
 
 [dev-dependencies]
 quote = "1.0.37"


### PR DESCRIPTION
This disables a lot of the serializer code that this crate does not need. While this does not completely address #37, it does reduce the cold compile-time slightly (on my high-end machine): 0.6 seconds.