### PR TITLE
Update documentation for crate_name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,10 +174,9 @@ type CrateNames = BTreeMap<String, FoundCrate>;
 ///
 /// # Returns
 ///
-/// - `Ok(orig_name)` if the crate was found, but not renamed in the `Cargo.toml`.
-/// - `Ok(RENAMED)` if the crate was found, but is renamed in the `Cargo.toml`. `RENAMED` will be
-/// the renamed name.
-/// - `Err` if an error occurred.
+/// - `Ok(FoundCrate::Itself)` the searched crate is the current crate being compiled.
+/// - `Ok(FoundCrate::Name(new_name))` the searched create was found with the given name Cargo.toml
+/// - `Err` if an error occurred. See [`Error`].
 ///
 /// The returned crate name is sanitized in such a way that it is a valid rust identifier. Thus,
 /// it is ready to be used in `extern crate` as identifier.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ type CrateNames = BTreeMap<String, FoundCrate>;
 /// # Returns
 ///
 /// - `Ok(FoundCrate::Itself)` the searched crate is the current crate being compiled.
-/// - `Ok(FoundCrate::Name(new_name))` the searched create was found with the given name Cargo.toml
+/// - `Ok(FoundCrate::Name(new_name))` the searched create was found with the given name in the `Cargo.toml`.
 /// - `Err` if an error occurred. See [`Error`].
 ///
 /// The returned crate name is sanitized in such a way that it is a valid rust identifier. Thus,


### PR DESCRIPTION
The current version of crate_names returns a `Result<FoundCrate, Error>`. Update the docs to describe the potential success values and refer to the Error enum.