### PR TITLE
Update `toml_edit` to 0.25.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all
   msrv:
-    name: "Check MSRV: 1.76.0"
+    name: "Check MSRV: 1.82.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -26,7 +26,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.76.0  # MSRV
+        toolchain: 1.82.0  # MSRV
     - uses: Swatinem/rust-cache@v2
     - name: Default features
       run: cargo test --all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all
   msrv:
-    name: "Check MSRV: 1.67.0"
+    name: "Check MSRV: 1.76.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -26,7 +26,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.67.0  # MSRV
+        toolchain: 1.76.0  # MSRV
     - uses: Swatinem/rust-cache@v2
     - name: Default features
       run: cargo test --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = """
 Replacement for crate (macro_rules keyword) in proc-macros
 """
 readme = "./README.md"
-rust-version = "1.76.0"
+rust-version = "1.82.0"
 
 [dependencies]
 toml_edit = { version = "0.25.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ description = """
 Replacement for crate (macro_rules keyword) in proc-macros
 """
 readme = "./README.md"
-rust-version = "1.67.0"
+rust-version = "1.76.0"
 
 [dependencies]
-toml_edit = { version = "0.23.2", default-features = false, features = [
+toml_edit = { version = "0.25.0", default-features = false, features = [
     "parse",
 ] }
 


### PR DESCRIPTION
`toml_edit 0.25.0` has just been released (along with `toml 1.0.0`!!) and first crates are picking it up. In order to prevent duplicates in my dependency tree, I'd like to see `proc-macro-crate` moving to `toml_edit 0.25.0` too.

This raises MSRV to 1.76.0 due to the requirement in `toml_edit 0.25.0`.

CC @bkchr